### PR TITLE
Adding `getClient` to `ChainDefinition`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ lib: ${SRC_FILES} package.json tsconfig.json node_modules rollup.config.js
 
 .PHONY: test
 test: node_modules
-	@TS_NODE_PROJECT='./test/tsconfig.json' \
+	@TS_NODE_PROJECT='./test/tsconfig.json' MOCK_DIR='./test/data' \
 		${BIN}/mocha ${MOCHA_OPTS} ${TEST_FILES} --no-timeout --grep '$(grep)'
 
 test/watch: node_modules
@@ -18,7 +18,7 @@ test/watch: node_modules
 		${BIN}/mocha --watch ${MOCHA_OPTS} ${TEST_FILES} --no-timeout --grep '$(grep)'
 
 build/coverage: ${SRC_FILES} ${TEST_FILES} node_modules
-	@TS_NODE_PROJECT='./test/tsconfig.json' \
+	@TS_NODE_PROJECT='./test/tsconfig.json' MOCK_DIR='./test/data' \
 		${BIN}/nyc ${NYC_OPTS} --reporter=html \
 		${BIN}/mocha ${MOCHA_OPTS} -R nyan ${TEST_FILES}
 
@@ -28,7 +28,7 @@ coverage: build/coverage
 
 .PHONY: ci-test
 ci-test: node_modules
-	@TS_NODE_PROJECT='./test/tsconfig.json' \
+	@TS_NODE_PROJECT='./test/tsconfig.json' MOCK_DIR='./test/data' \
 		${BIN}/nyc ${NYC_OPTS} --reporter=text \
 		${BIN}/mocha ${MOCHA_OPTS} -R list ${TEST_FILES}
 

--- a/package.json
+++ b/package.json
@@ -17,8 +17,9 @@
         "prepare": "make"
     },
     "dependencies": {
-        "@wharfkit/apiclient-leap": "^4.0.3",
-        "@wharfkit/apiclient-wax": "^4.0.2",
+        "@wharfkit/apiclient-leap": "^4.0.5",
+        "@wharfkit/apiclient-telos": "^4.0.5",
+        "@wharfkit/apiclient-wax": "^4.0.5",
         "tslib": "^2.1.0"
     },
     "peerDependencies": {
@@ -41,6 +42,7 @@
         "@typescript-eslint/parser": "^5.20.0",
         "@wharfkit/antelope": "^0.9.0-rc2",
         "@wharfkit/mock-data": "^1.0.2",
+        "@wharfkit/session": "^1.0.0",
         "chai": "^4.3.4",
         "eslint": "^8.13.0",
         "eslint-config-prettier": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@wharfkit/common",
     "description": "Common data and functions shared across WharfKit packages",
-    "version": "1.2.0-rc1",
+    "version": "1.2.0-rc2",
     "homepage": "https://github.com/wharfkit/common",
     "license": "BSD-3-Clause",
     "main": "lib/common.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@wharfkit/common",
     "description": "Common data and functions shared across WharfKit packages",
-    "version": "1.1.0",
+    "version": "1.2.0-rc1",
     "homepage": "https://github.com/wharfkit/common",
     "license": "BSD-3-Clause",
     "main": "lib/common.js",
@@ -17,10 +17,12 @@
         "prepare": "make"
     },
     "dependencies": {
+        "@wharfkit/apiclient-leap": "^4.0.3",
+        "@wharfkit/apiclient-wax": "^4.0.2",
         "tslib": "^2.1.0"
     },
     "peerDependencies": {
-        "@wharfkit/antelope": "^0.7.3"
+        "@wharfkit/antelope": "^0.9.0-rc2"
     },
     "devDependencies": {
         "@babel/preset-env": "^7.20.2",
@@ -37,7 +39,8 @@
         "@types/node": "^18.7.18",
         "@typescript-eslint/eslint-plugin": "^5.20.0",
         "@typescript-eslint/parser": "^5.20.0",
-        "@wharfkit/antelope": "^0.7.3",
+        "@wharfkit/antelope": "^0.9.0-rc2",
+        "@wharfkit/mock-data": "^1.0.2",
         "chai": "^4.3.4",
         "eslint": "^8.13.0",
         "eslint-config-prettier": "^8.1.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,7 +3,7 @@ import typescript from '@rollup/plugin-typescript'
 import cleanup from 'rollup-plugin-cleanup'
 import pkg from './package.json'
 
-const external = Object.keys(pkg.peerDependencies)
+const external = [...Object.keys(pkg.dependencies), ...Object.keys(pkg.peerDependencies)]
 
 /** @type {import('rollup').RollupOptions} */
 export default [

--- a/src/common/chains.ts
+++ b/src/common/chains.ts
@@ -1,7 +1,7 @@
 import {APIClientOptions, Checksum256, Checksum256Type, Struct} from '@wharfkit/antelope'
 
 import {APIClient as LeapAPIClient} from '@wharfkit/apiclient-leap'
-import {APIClient as TelosAPIClient} from '@wharfkit/apiclient-leap'
+import {APIClient as TelosAPIClient} from '@wharfkit/apiclient-telos'
 import {APIClient as WAXAPIClient} from '@wharfkit/apiclient-wax'
 
 import {ExplorerDefinition} from './explorer'
@@ -10,116 +10,9 @@ import {Logo} from './logo'
 import type {ExplorerDefinitionType, LogoType} from './types'
 
 /**
- * The information required to interact with a given chain.
- */
-@Struct.type('chain_definition')
-export class ChainDefinition<ChainIndice extends ChainIndices = 'Antelope'> extends Struct {
-    /**
-     * The chain ID.
-     */
-    @Struct.field('checksum256') declare id: Checksum256
-
-    /**
-     * The base URL of the chain's API endpoint (e.g. https://jungle4.greymass.com).
-     */
-    @Struct.field('string') declare url: string
-
-    /**
-     * The absolute URL(s) to the chain's logo.
-     */
-    @Struct.field(Logo, {optional: true}) declare logo?: LogoType
-
-    /**
-     * The explorer definition for the chain.
-     */
-    @Struct.field(ExplorerDefinition, {optional: true}) declare explorer?: ExplorerDefinitionType
-
-    static from<ChainIndice extends ChainIndices = 'Antelope'>(data) {
-        return super.from({
-            ...data,
-            explorer: data.explorer ? ExplorerDefinition.from(data.explorer) : undefined,
-            logo: data.logo ? Logo.from(data.logo) : undefined,
-        }) as ChainDefinition<ChainIndice>
-    }
-
-    get name() {
-        const indice = chainIdsToIndices.get(String(this.id))
-        if (!indice) {
-            return 'Unknown blockchain'
-        }
-        return ChainNames[indice]
-    }
-
-    public getLogo(): Logo | undefined {
-        const id = String(this.id)
-        if (this.logo) {
-            return Logo.from(this.logo)
-        }
-        if (chainLogos.has(id)) {
-            const logo = chainLogos.get(id)
-            if (logo) {
-                return Logo.from(logo)
-            }
-        }
-        return undefined
-    }
-
-    public getClient(options?: APIClientOptions): ClientType<ChainIndice> {
-        // Create options that default to URL defined in ChainDefinition
-        const opts = {
-            url: this.url,
-            ...options,
-        }
-        // Determine if we have a custom client for this chain
-        const indice = chainIdsToIndices.get(String(this.id))
-        if (indice) {
-            const client = ChainClients[indice]
-            if (client) {
-                // Return defined client
-                return new client(opts) as ClientType<ChainIndice>
-            }
-        }
-        // Return generic APIClient when unknown blockchain
-        return new LeapAPIClient(opts) as ClientType<ChainIndice>
-    }
-}
-
-// Type exports based on ChainClients
-export type ClientType<T> =
-    // Override WAX
-    T extends 'WAX'
-        ? WAXAPIClient
-        : // Override WAX Testnet
-        T extends 'WAXTestnet'
-        ? WAXAPIClient
-        : // Override Telos
-        T extends 'Telos'
-        ? TelosAPIClient
-        : // Override Telos Testnet
-        T extends 'TelosTestnet'
-        ? TelosAPIClient
-        : // Default to Leap
-          LeapAPIClient
-
-export type ChainClientsTypes<I extends string> = {
-    [K in I]: typeof LeapAPIClient
-}
-
-/**
- * A mapping of specific chains to their APIClients
- */
-export const ChainClients: Partial<ChainClientsTypes<ChainIndices>> = {
-    Antelope: LeapAPIClient,
-    Telos: TelosAPIClient,
-    TelosTestnet: TelosAPIClient,
-    WAX: WAXAPIClient,
-    WAXTestnet: WAXAPIClient,
-}
-
-/**
  * A list of string-based chain names to assist autocompletion
  */
-export type ChainIndices =
+export type ChainKeys =
     | 'Antelope'
     | 'EOS'
     | 'FIO'
@@ -137,124 +30,9 @@ export type ChainIndices =
     | 'UX'
 
 /**
- * List of human readable chain names based on the ChainIndices type.
- */
-export const ChainNames: Record<ChainIndices, string> = {
-    Antelope: 'Unknown Antelope Chain',
-    EOS: 'EOS',
-    FIO: 'FIO',
-    FIOTestnet: 'FIO (Testnet)',
-    Jungle4: 'Jungle 4 (Testnet)',
-    KylinTestnet: 'Kylin (Testnet)',
-    Libre: 'Libre',
-    LibreTestnet: 'Libre (Testnet)',
-    Proton: 'Proton',
-    ProtonTestnet: 'Proton (Testnet)',
-    Telos: 'Telos',
-    TelosTestnet: 'Telos (Testnet)',
-    WAX: 'WAX',
-    WAXTestnet: 'WAX (Testnet)',
-    UX: 'UX Network',
-}
-
-/**
- * An exported list of ChainDefinition entries for select chains.
- */
-export const Chains = {
-    EOS: ChainDefinition.from({
-        id: 'aca376f206b8fc25a6ed44dbdc66547c36c6c33e3a119ffbeaef943642f0e906',
-        url: 'https://eos.greymass.com',
-        explorer: {
-            prefix: 'https://bloks.io/transaction/',
-            suffix: '',
-        },
-    }),
-    FIO: ChainDefinition.from({
-        id: '21dcae42c0182200e93f954a074011f9048a7624c6fe81d3c9541a614a88bd1c',
-        url: 'https://fio.greymass.com',
-        explorer: {
-            prefix: 'https://fio.bloks.io/transaction/',
-            suffix: '',
-        },
-    }),
-    FIOTestnet: ChainDefinition.from({
-        id: 'b20901380af44ef59c5918439a1f9a41d83669020319a80574b804a5f95cbd7e',
-        url: 'https://fiotestnet.greymass.com',
-        explorer: {
-            prefix: 'https://fio-test.bloks.io/transaction/',
-            suffix: '',
-        },
-    }),
-    Jungle4: ChainDefinition.from({
-        id: '73e4385a2708e6d7048834fbc1079f2fabb17b3c125b146af438971e90716c4d',
-        url: 'https://jungle4.greymass.com',
-    }),
-    KylinTestnet: ChainDefinition.from({
-        id: '5fff1dae8dc8e2fc4d5b23b2c7665c97f9e9d8edf2b6485a86ba311c25639191',
-        url: 'https://api.kylin.alohaeos.com',
-    }),
-    Libre: ChainDefinition.from({
-        id: '38b1d7815474d0c60683ecbea321d723e83f5da6ae5f1c1f9fecc69d9ba96465',
-        url: 'https://libre.greymass.com',
-        explorer: {
-            prefix: 'https://www.libreblocks.io/tx/',
-            suffix: '',
-        },
-    }),
-    LibreTestnet: ChainDefinition.from({
-        id: 'b64646740308df2ee06c6b72f34c0f7fa066d940e831f752db2006fcc2b78dee',
-        url: 'https://libretestnet.greymass.com',
-    }),
-    Proton: ChainDefinition.from({
-        id: '384da888112027f0321850a169f737c33e53b388aad48b5adace4bab97f437e0',
-        url: 'https://proton.greymass.com',
-        explorer: {
-            prefix: 'https://www.protonscan.io/transaction/',
-            suffix: '',
-        },
-    }),
-    ProtonTestnet: ChainDefinition.from({
-        id: '71ee83bcf52142d61019d95f9cc5427ba6a0d7ff8accd9e2088ae2abeaf3d3dd',
-        url: 'https://proton-testnet.greymass.com',
-    }),
-    Telos: ChainDefinition.from<'Telos'>({
-        id: '4667b205c6838ef70ff7988f6e8257e8be0e1284a2f59699054a018f743b1d11',
-        url: 'https://telos.greymass.com',
-        explorer: {
-            prefix: 'https://explorer.telos.net/transaction/',
-            suffix: '',
-        },
-    }),
-    TelosTestnet: ChainDefinition.from<'TelosTestnet'>({
-        id: '1eaa0824707c8c16bd25145493bf062aecddfeb56c736f6ba6397f3195f33c9f',
-        url: 'https://telos.greymass.com',
-    }),
-    WAX: ChainDefinition.from<'WAX'>({
-        id: '1064487b3cd1a897ce03ae5b6a865651747e2e152090f99c1d19d44e01aea5a4',
-        url: 'https://wax.greymass.com',
-        explorer: {
-            prefix: 'https://waxblock.io/transaction/',
-            suffix: '',
-        },
-    }),
-    WAXTestnet: ChainDefinition.from<'WAXTestnet'>({
-        id: 'f16b1833c747c43682f4386fca9cbb327929334a762755ebec17f6f23c9b8a12',
-        url: 'https://waxtestnet.greymass.com',
-    }),
-    UX: ChainDefinition.from({
-        id: '8fc6dce7942189f842170de953932b1f66693ad3788f766e777b6f9d22335c02',
-        url: 'https://api.uxnetwork.io',
-        explorer: {
-            prefix: 'https://explorer.uxnetwork.io/tx/',
-            suffix: '',
-        },
-    }),
-}
-
-/**
  * A list of chain IDs and their ChainIndices for reference lookups
  */
-export const chainIdsToIndices: Map<Checksum256Type, ChainIndices> = new Map([
+export const chainIdsToIndices: Map<Checksum256Type, ChainKeys> = new Map([
     ['aca376f206b8fc25a6ed44dbdc66547c36c6c33e3a119ffbeaef943642f0e906', 'EOS'],
     ['21dcae42c0182200e93f954a074011f9048a7624c6fe81d3c9541a614a88bd1c', 'FIO'],
     ['b20901380af44ef59c5918439a1f9a41d83669020319a80574b804a5f95cbd7e', 'FIOTestnet'],
@@ -272,63 +50,247 @@ export const chainIdsToIndices: Map<Checksum256Type, ChainIndices> = new Map([
 ])
 
 /**
- * A list of known chain IDs and their logos.
+ * APIClient class instances used for each Chain
  */
-export const chainLogos: Map<Checksum256Type, LogoType> = new Map([
-    [
-        'aca376f206b8fc25a6ed44dbdc66547c36c6c33e3a119ffbeaef943642f0e906',
-        'https://assets.wharfkit.com/chain/eos.png',
-    ],
-    [
-        '21dcae42c0182200e93f954a074011f9048a7624c6fe81d3c9541a614a88bd1c',
-        'https://assets.wharfkit.com/chain/fio.png',
-    ],
-    [
-        'b20901380af44ef59c5918439a1f9a41d83669020319a80574b804a5f95cbd7e',
-        'https://assets.wharfkit.com/chain/fio.png',
-    ],
-    [
-        '2a02a0053e5a8cf73a56ba0fda11e4d92e0238a4a2aa74fccf46d5a910746840',
-        'https://assets.wharfkit.com/chain/jungle.png',
-    ],
-    [
-        '73e4385a2708e6d7048834fbc1079f2fabb17b3c125b146af438971e90716c4d',
-        'https://assets.wharfkit.com/chain/jungle.png',
-    ],
-    [
-        '38b1d7815474d0c60683ecbea321d723e83f5da6ae5f1c1f9fecc69d9ba96465',
-        'https://assets.wharfkit.com/chain/libre.png',
-    ],
-    [
-        'b64646740308df2ee06c6b72f34c0f7fa066d940e831f752db2006fcc2b78dee',
-        'https://assets.wharfkit.com/chain/libre.png',
-    ],
-    [
-        '384da888112027f0321850a169f737c33e53b388aad48b5adace4bab97f437e0',
-        'https://assets.wharfkit.com/chain/proton.png',
-    ],
-    [
-        '71ee83bcf52142d61019d95f9cc5427ba6a0d7ff8accd9e2088ae2abeaf3d3dd',
-        'https://assets.wharfkit.com/chain/proton.png',
-    ],
-    [
-        '4667b205c6838ef70ff7988f6e8257e8be0e1284a2f59699054a018f743b1d11',
-        'https://assets.wharfkit.com/chain/telos.png',
-    ],
-    [
-        '1eaa0824707c8c16bd25145493bf062aecddfeb56c736f6ba6397f3195f33c9f',
-        'https://assets.wharfkit.com/chain/telos.png',
-    ],
-    [
-        '8fc6dce7942189f842170de953932b1f66693ad3788f766e777b6f9d22335c02',
-        'https://assets.wharfkit.com/chain/ux.png',
-    ],
-    [
-        '1064487b3cd1a897ce03ae5b6a865651747e2e152090f99c1d19d44e01aea5a4',
-        'https://assets.wharfkit.com/chain/wax.png',
-    ],
-    [
-        'f16b1833c747c43682f4386fca9cbb327929334a762755ebec17f6f23c9b8a12',
-        'https://assets.wharfkit.com/chain/wax.png',
-    ],
-])
+const ChainClients: Record<ChainKeys, typeof LeapAPIClient> = {
+    // Generic Leap clients
+    Antelope: LeapAPIClient,
+    EOS: LeapAPIClient,
+    FIO: LeapAPIClient,
+    FIOTestnet: LeapAPIClient,
+    Jungle4: LeapAPIClient,
+    KylinTestnet: LeapAPIClient,
+    Libre: LeapAPIClient,
+    LibreTestnet: LeapAPIClient,
+    Proton: LeapAPIClient,
+    ProtonTestnet: LeapAPIClient,
+    UX: LeapAPIClient,
+    // Telos clients
+    Telos: TelosAPIClient,
+    TelosTestnet: TelosAPIClient,
+    // WAX clients
+    WAX: WAXAPIClient,
+    WAXTestnet: WAXAPIClient,
+}
+
+/**
+ * Type mapping for APIClient classes by Chain
+ */
+export type ClientType<T> =
+    // Override WAX
+    T extends 'WAX'
+        ? WAXAPIClient
+        : // Override WAX Testnet
+        T extends 'WAXTestnet'
+        ? WAXAPIClient
+        : // Override Telos
+        T extends 'Telos'
+        ? TelosAPIClient
+        : // Override Telos Testnet
+        T extends 'TelosTestnet'
+        ? TelosAPIClient
+        : // Default to Leap
+          LeapAPIClient
+
+/**
+ * Method to return a specific chain client given an ID
+ */
+export function getChainClient<ChainName extends ChainKeys = 'Antelope'>(
+    id: Checksum256Type,
+    options: APIClientOptions
+): ClientType<ChainName> {
+    // Determine if we have a custom client for this chain
+    const indice = chainIdsToIndices.get(String(id))
+    if (indice) {
+        return new ChainClients[indice](options) as ClientType<ChainName>
+    }
+    // Return generic APIClient when unknown blockchain
+    return new LeapAPIClient(options) as ClientType<ChainName>
+}
+
+/**
+ * A definition that defines the connection information and metadata for a specific chain
+ */
+@Struct.type('chain_definition')
+export class ChainDefinition<ChainName extends ChainKeys = 'Antelope'> extends Struct {
+    /**
+     * The chain ID.
+     */
+    @Struct.field('checksum256') declare id: Checksum256
+
+    /**
+     * The base URL of the chain's API endpoint (e.g. https://jungle4.greymass.com).
+     */
+    @Struct.field('string') declare url: string
+
+    /**
+     * The human readable name for the chain
+     */
+    @Struct.field('string', {optional: true}) declare name: string
+
+    /**
+     * The absolute URL(s) to the chain's logo.
+     */
+    @Struct.field(Logo, {optional: true}) declare logo?: LogoType
+
+    /**
+     * The explorer definition for the chain.
+     */
+    @Struct.field(ExplorerDefinition, {optional: true}) declare explorer?: ExplorerDefinitionType
+
+    static from<ChainName extends ChainKeys = 'Antelope'>(data) {
+        const detected = chainIdsToIndices.get(String(data.id))
+        if (detected) {
+            const clientType = ChainClients[detected]
+            if (clientType) {
+                return super.from({
+                    ...data,
+                    explorer: data.explorer ? ExplorerDefinition.from(data.explorer) : undefined,
+                    logo: data.logo ? Logo.from(data.logo) : undefined,
+                }) as ChainDefinition<ChainName>
+            }
+        }
+        return super.from({
+            ...data,
+            explorer: data.explorer ? ExplorerDefinition.from(data.explorer) : undefined,
+            logo: data.logo ? Logo.from(data.logo) : undefined,
+        }) as ChainDefinition<ChainName>
+    }
+
+    public getLogo(): Logo | undefined {
+        if (this.logo) {
+            return Logo.from(this.logo)
+        }
+        return undefined
+    }
+
+    public getClient(options?: APIClientOptions) {
+        // Create options that default to URL defined in ChainDefinition
+        const opts = {
+            url: this.url,
+            ...options,
+        }
+        return getChainClient<ChainName>(this.id, opts)
+    }
+}
+
+/**
+ * An exported list of known ChainDefinition entries for immediate use.
+ */
+export const Chains = {
+    EOS: ChainDefinition.from<'EOS'>({
+        id: 'aca376f206b8fc25a6ed44dbdc66547c36c6c33e3a119ffbeaef943642f0e906',
+        url: 'https://eos.greymass.com',
+        name: 'EOS',
+        logo: 'https://assets.wharfkit.com/chain/eos.png',
+        explorer: {
+            prefix: 'https://bloks.io/transaction/',
+            suffix: '',
+        },
+    }),
+    FIO: ChainDefinition.from<'FIO'>({
+        id: '21dcae42c0182200e93f954a074011f9048a7624c6fe81d3c9541a614a88bd1c',
+        url: 'https://fio.greymass.com',
+        name: 'FIO',
+        logo: 'https://assets.wharfkit.com/chain/fio.png',
+        explorer: {
+            prefix: 'https://fio.bloks.io/transaction/',
+            suffix: '',
+        },
+    }),
+    FIOTestnet: ChainDefinition.from<'FIOTestnet'>({
+        id: 'b20901380af44ef59c5918439a1f9a41d83669020319a80574b804a5f95cbd7e',
+        url: 'https://fiotestnet.greymass.com',
+        name: 'FIO (Testnet)',
+        logo: 'https://assets.wharfkit.com/chain/fio.png',
+        explorer: {
+            prefix: 'https://fio-test.bloks.io/transaction/',
+            suffix: '',
+        },
+    }),
+    Jungle4: ChainDefinition.from<'Jungle4'>({
+        id: '73e4385a2708e6d7048834fbc1079f2fabb17b3c125b146af438971e90716c4d',
+        url: 'https://jungle4.greymass.com',
+        name: 'Jungle 4 (Testnet)',
+        logo: 'https://assets.wharfkit.com/chain/jungle.png',
+    }),
+    KylinTestnet: ChainDefinition.from<'KylinTestnet'>({
+        id: '5fff1dae8dc8e2fc4d5b23b2c7665c97f9e9d8edf2b6485a86ba311c25639191',
+        url: 'https://api.kylin.alohaeos.com',
+        name: 'Kylin (Testnet)',
+    }),
+    Libre: ChainDefinition.from<'Libre'>({
+        id: '38b1d7815474d0c60683ecbea321d723e83f5da6ae5f1c1f9fecc69d9ba96465',
+        url: 'https://libre.greymass.com',
+        name: 'Libre',
+        logo: 'https://assets.wharfkit.com/chain/libre.png',
+        explorer: {
+            prefix: 'https://www.libreblocks.io/tx/',
+            suffix: '',
+        },
+    }),
+    LibreTestnet: ChainDefinition.from<'LibreTestnet'>({
+        id: 'b64646740308df2ee06c6b72f34c0f7fa066d940e831f752db2006fcc2b78dee',
+        url: 'https://libretestnet.greymass.com',
+        name: 'Libre (Testnet)',
+        logo: 'https://assets.wharfkit.com/chain/libre.png',
+    }),
+    Proton: ChainDefinition.from<'Proton'>({
+        id: '384da888112027f0321850a169f737c33e53b388aad48b5adace4bab97f437e0',
+        url: 'https://proton.greymass.com',
+        name: 'Proton',
+        logo: 'https://assets.wharfkit.com/chain/proton.png',
+        explorer: {
+            prefix: 'https://www.protonscan.io/transaction/',
+            suffix: '',
+        },
+    }),
+    ProtonTestnet: ChainDefinition.from<'ProtonTestnet'>({
+        id: '71ee83bcf52142d61019d95f9cc5427ba6a0d7ff8accd9e2088ae2abeaf3d3dd',
+        url: 'https://proton-testnet.greymass.com',
+        name: 'Proton (Testnet)',
+        logo: 'https://assets.wharfkit.com/chain/proton.png',
+    }),
+    Telos: ChainDefinition.from<'Telos'>({
+        id: '4667b205c6838ef70ff7988f6e8257e8be0e1284a2f59699054a018f743b1d11',
+        url: 'https://telos.greymass.com',
+        name: 'Telos',
+        logo: 'https://assets.wharfkit.com/chain/telos.png',
+        explorer: {
+            prefix: 'https://explorer.telos.net/transaction/',
+            suffix: '',
+        },
+    }),
+    TelosTestnet: ChainDefinition.from<'TelosTestnet'>({
+        id: '1eaa0824707c8c16bd25145493bf062aecddfeb56c736f6ba6397f3195f33c9f',
+        url: 'https://telos.greymass.com',
+        name: 'Telos (Testnet)',
+        logo: 'https://assets.wharfkit.com/chain/telos.png',
+    }),
+    WAX: ChainDefinition.from<'WAX'>({
+        id: '1064487b3cd1a897ce03ae5b6a865651747e2e152090f99c1d19d44e01aea5a4',
+        url: 'https://wax.greymass.com',
+        name: 'WAX',
+        logo: 'https://assets.wharfkit.com/chain/wax.png',
+        explorer: {
+            prefix: 'https://waxblock.io/transaction/',
+            suffix: '',
+        },
+    }),
+    WAXTestnet: ChainDefinition.from<'WAXTestnet'>({
+        id: 'f16b1833c747c43682f4386fca9cbb327929334a762755ebec17f6f23c9b8a12',
+        url: 'https://waxtestnet.greymass.com',
+        name: 'WAX (Testnet)',
+        logo: 'https://assets.wharfkit.com/chain/wax.png',
+    }),
+    UX: ChainDefinition.from<'UX'>({
+        id: '8fc6dce7942189f842170de953932b1f66693ad3788f766e777b6f9d22335c02',
+        url: 'https://api.uxnetwork.io',
+        name: 'UX Network',
+        logo: 'https://assets.wharfkit.com/chain/ux.png',
+        explorer: {
+            prefix: 'https://explorer.uxnetwork.io/tx/',
+            suffix: '',
+        },
+    }),
+}

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,6 +1,6 @@
 import {Checksum256Type} from '@wharfkit/antelope'
 
-import {ChainDefinition} from './chains'
+import {ChainDefinition, ChainKeys} from './chains'
 import {ExplorerDefinition} from './explorer'
 import {Logo} from './logo'
 
@@ -12,8 +12,14 @@ export type ExplorerDefinitionType =
     | ExplorerDefinition
     | {prefix: string; suffix: string; url: (id: string) => string}
 
-export type ChainDefinitionType =
-    | ChainDefinition
-    | {id: Checksum256Type; url: string; explorer?: ExplorerDefinitionType; logo?: LogoType}
+export type ChainDefinitionType<T extends ChainKeys = 'Antelope'> =
+    | ChainDefinition<T>
+    | {
+          id: Checksum256Type
+          url: string
+          name?: string
+          explorer?: ExplorerDefinitionType
+          logo?: LogoType
+      }
 
 export type LocaleDefinitions = Record<string, any>

--- a/test/data/1068183311566483d75b86a6da056815f2387184.json
+++ b/test/data/1068183311566483d75b86a6da056815f2387184.json
@@ -1,0 +1,32 @@
+{
+    "request": {
+        "path": "https://eos.greymass.com/v1/chain/get_info",
+        "params": {
+            "method": "POST"
+        }
+    },
+    "status": 200,
+    "json": {
+        "server_version": "43873e82",
+        "chain_id": "aca376f206b8fc25a6ed44dbdc66547c36c6c33e3a119ffbeaef943642f0e906",
+        "head_block_num": 328129279,
+        "last_irreversible_block_num": 328128954,
+        "last_irreversible_block_id": "138ed9ba7819e0b797b9ef24915e2d96a94ad4f22b578d3b983a43143deb2ea3",
+        "head_block_id": "138edaff7955888f12a7f5d2d288ff49ccbc42ee4f96d57d1ddf29b9678e77ce",
+        "head_block_time": "2023-08-28T20:00:18.000",
+        "head_block_producer": "atticlabeosb",
+        "virtual_block_cpu_limit": 200000,
+        "virtual_block_net_limit": 1048576000,
+        "block_cpu_limit": 200000,
+        "block_net_limit": 1048576,
+        "server_version_string": "v3.2.3-hotfix",
+        "fork_db_head_block_num": 328129279,
+        "fork_db_head_block_id": "138edaff7955888f12a7f5d2d288ff49ccbc42ee4f96d57d1ddf29b9678e77ce",
+        "server_full_version_string": "v3.2.3-hotfix-43873e822160be5e5f364fd867e3c7d27162cd0c-dirty",
+        "total_cpu_weight": "383375678612944",
+        "total_net_weight": "96156749298177",
+        "earliest_available_block_num": 327956125,
+        "last_irreversible_block_time": "2023-08-28T19:57:35.500"
+    },
+    "text": "{\"server_version\":\"43873e82\",\"chain_id\":\"aca376f206b8fc25a6ed44dbdc66547c36c6c33e3a119ffbeaef943642f0e906\",\"head_block_num\":328129279,\"last_irreversible_block_num\":328128954,\"last_irreversible_block_id\":\"138ed9ba7819e0b797b9ef24915e2d96a94ad4f22b578d3b983a43143deb2ea3\",\"head_block_id\":\"138edaff7955888f12a7f5d2d288ff49ccbc42ee4f96d57d1ddf29b9678e77ce\",\"head_block_time\":\"2023-08-28T20:00:18.000\",\"head_block_producer\":\"atticlabeosb\",\"virtual_block_cpu_limit\":200000,\"virtual_block_net_limit\":1048576000,\"block_cpu_limit\":200000,\"block_net_limit\":1048576,\"server_version_string\":\"v3.2.3-hotfix\",\"fork_db_head_block_num\":328129279,\"fork_db_head_block_id\":\"138edaff7955888f12a7f5d2d288ff49ccbc42ee4f96d57d1ddf29b9678e77ce\",\"server_full_version_string\":\"v3.2.3-hotfix-43873e822160be5e5f364fd867e3c7d27162cd0c-dirty\",\"total_cpu_weight\":\"383375678612944\",\"total_net_weight\":\"96156749298177\",\"earliest_available_block_num\":327956125,\"last_irreversible_block_time\":\"2023-08-28T19:57:35.500\"}"
+}

--- a/test/data/16063f7e528ffcee61e70f1aeb4ff6c88a17492b.json
+++ b/test/data/16063f7e528ffcee61e70f1aeb4ff6c88a17492b.json
@@ -1,0 +1,272 @@
+{
+    "request": {
+        "path": "https://eos.greymass.com/v1/chain/get_account",
+        "params": {
+            "method": "POST",
+            "body": "{\"account_name\":\"teamgreymass\"}"
+        }
+    },
+    "status": 200,
+    "json": {
+        "account_name": "teamgreymass",
+        "head_block_num": 328129337,
+        "head_block_time": "2023-08-28T20:00:47.000",
+        "privileged": false,
+        "last_code_update": "1970-01-01T00:00:00.000",
+        "created": "2018-06-10T13:04:15.000",
+        "core_liquid_balance": "4697.6642 EOS",
+        "ram_quota": 67988,
+        "net_weight": 4496541,
+        "cpu_weight": "13483146062",
+        "net_limit": {
+            "used": 242265,
+            "available": 8230837,
+            "max": 8473102,
+            "last_usage_update_time": "2023-08-28T20:00:36.500",
+            "current_used": 242236
+        },
+        "cpu_limit": {
+            "used": 977684,
+            "available": 237775,
+            "max": 1215459,
+            "last_usage_update_time": "2023-08-28T20:00:36.500",
+            "current_used": 977565
+        },
+        "ram_usage": 18101,
+        "permissions": [
+            {
+                "perm_name": "active",
+                "parent": "owner",
+                "required_auth": {
+                    "threshold": 1,
+                    "keys": [
+                        {
+                            "key": "EOS6gqJ7sdPgjHLFLtks9cRPs5qYHa9U3CwK4P2JasTLWKQ9kXZK1",
+                            "weight": 1
+                        }
+                    ],
+                    "accounts": [],
+                    "waits": []
+                },
+                "linked_actions": []
+            },
+            {
+                "perm_name": "claim",
+                "parent": "active",
+                "required_auth": {
+                    "threshold": 1,
+                    "keys": [
+                        {
+                            "key": "EOS6DLD9HxMcwn73U41jjdGsNe9vDFRKB26um6qTAqrtYcJFtED4C",
+                            "weight": 1
+                        }
+                    ],
+                    "accounts": [],
+                    "waits": []
+                },
+                "linked_actions": [
+                    {
+                        "account": "eosio",
+                        "action": "claimrewards"
+                    }
+                ]
+            },
+            {
+                "perm_name": "decentium",
+                "parent": "active",
+                "required_auth": {
+                    "threshold": 1,
+                    "keys": [
+                        {
+                            "key": "EOS7knG7M5TUEdRv1bkVjTPddVoDQnwS7oEZXAgFk3A4hhocA3eJf",
+                            "weight": 1
+                        }
+                    ],
+                    "accounts": [],
+                    "waits": []
+                },
+                "linked_actions": [
+                    {
+                        "account": "decentiumorg"
+                    }
+                ]
+            },
+            {
+                "perm_name": "killswitch",
+                "parent": "active",
+                "required_auth": {
+                    "threshold": 1,
+                    "keys": [
+                        {
+                            "key": "EOS7CjC7GL71msPzAuAzd2WwiBEAzTcPL47ACrjSuiNmnnGGufYSn",
+                            "weight": 1
+                        }
+                    ],
+                    "accounts": [],
+                    "waits": []
+                },
+                "linked_actions": [
+                    {
+                        "account": "eosio",
+                        "action": "unregprod"
+                    }
+                ]
+            },
+            {
+                "perm_name": "oracle",
+                "parent": "active",
+                "required_auth": {
+                    "threshold": 1,
+                    "keys": [
+                        {
+                            "key": "EOS88VqmDmJJ9S23eNqdeWYf2zySxv3ckQrWBKy7EvVRCUuhSU4f3",
+                            "weight": 1
+                        }
+                    ],
+                    "accounts": [],
+                    "waits": []
+                },
+                "linked_actions": [
+                    {
+                        "account": "delphioracle",
+                        "action": "write"
+                    }
+                ]
+            },
+            {
+                "perm_name": "owner",
+                "parent": "",
+                "required_auth": {
+                    "threshold": 1,
+                    "keys": [
+                        {
+                            "key": "EOS8QzGtCea2thiqcTVeXGdyRZpdKYptQznbcWSMj73FD5RgwKN82",
+                            "weight": 1
+                        }
+                    ],
+                    "accounts": [],
+                    "waits": []
+                },
+                "linked_actions": []
+            },
+            {
+                "perm_name": "producerjson",
+                "parent": "active",
+                "required_auth": {
+                    "threshold": 1,
+                    "keys": [
+                        {
+                            "key": "EOS5JCEciUdfXnQmTyj85T98bXTAZZ1g7Nmajseu7ZWB8DrDa6Etp",
+                            "weight": 1
+                        }
+                    ],
+                    "accounts": [],
+                    "waits": []
+                },
+                "linked_actions": [
+                    {
+                        "account": "producerjson",
+                        "action": "set"
+                    }
+                ]
+            },
+            {
+                "perm_name": "transfer",
+                "parent": "active",
+                "required_auth": {
+                    "threshold": 1,
+                    "keys": [
+                        {
+                            "key": "EOS7qZ8nnmn6KBnjQL4oukyZFWCj8DmC9nJE2nkAYAZbwgKhMu8cW",
+                            "weight": 1
+                        }
+                    ],
+                    "accounts": [],
+                    "waits": []
+                },
+                "linked_actions": [
+                    {
+                        "account": "eosio.token",
+                        "action": "transfer"
+                    }
+                ]
+            },
+            {
+                "perm_name": "vote",
+                "parent": "active",
+                "required_auth": {
+                    "threshold": 1,
+                    "keys": [
+                        {
+                            "key": "EOS65NrHPVXaV4voxepQREmYCmnMJm4tAWdxPaK46CbUN1rrVmRzg",
+                            "weight": 1
+                        }
+                    ],
+                    "accounts": [],
+                    "waits": []
+                },
+                "linked_actions": [
+                    {
+                        "account": "eosio",
+                        "action": "voteproducer"
+                    }
+                ]
+            },
+            {
+                "perm_name": "voting",
+                "parent": "active",
+                "required_auth": {
+                    "threshold": 1,
+                    "keys": [
+                        {
+                            "key": "EOS7pn6P5FftyNAKRfx9VcUzBFMvC4UitNbnoKbfxNe8SShELo2it",
+                            "weight": 1
+                        }
+                    ],
+                    "accounts": [],
+                    "waits": []
+                },
+                "linked_actions": [
+                    {
+                        "account": "eosio.forum",
+                        "action": "vote"
+                    },
+                    {
+                        "account": "eosio.forum",
+                        "action": "unvote"
+                    }
+                ]
+            }
+        ],
+        "total_resources": {
+            "owner": "teamgreymass",
+            "net_weight": "449.6541 EOS",
+            "cpu_weight": "1348314.6062 EOS",
+            "ram_bytes": 66588
+        },
+        "self_delegated_bandwidth": null,
+        "refund_request": null,
+        "voter_info": {
+            "owner": "teamgreymass",
+            "proxy": "greymassvote",
+            "producers": [],
+            "staked": 100202,
+            "last_vote_weight": "863265464502.93908691406250000",
+            "proxied_vote_weight": "0.00000000000000000",
+            "is_proxy": 0,
+            "flags1": 0,
+            "reserved2": 0,
+            "reserved3": "0.0000 EOS"
+        },
+        "rex_info": null,
+        "subjective_cpu_bill_limit": {
+            "used": 0,
+            "available": 0,
+            "max": 0,
+            "last_usage_update_time": "2000-01-01T00:00:00.000",
+            "current_used": 0
+        },
+        "eosio_any_linked_actions": []
+    },
+    "text": "{\"account_name\":\"teamgreymass\",\"head_block_num\":328129337,\"head_block_time\":\"2023-08-28T20:00:47.000\",\"privileged\":false,\"last_code_update\":\"1970-01-01T00:00:00.000\",\"created\":\"2018-06-10T13:04:15.000\",\"core_liquid_balance\":\"4697.6642 EOS\",\"ram_quota\":67988,\"net_weight\":4496541,\"cpu_weight\":\"13483146062\",\"net_limit\":{\"used\":242265,\"available\":8230837,\"max\":8473102,\"last_usage_update_time\":\"2023-08-28T20:00:36.500\",\"current_used\":242236},\"cpu_limit\":{\"used\":977684,\"available\":237775,\"max\":1215459,\"last_usage_update_time\":\"2023-08-28T20:00:36.500\",\"current_used\":977565},\"ram_usage\":18101,\"permissions\":[{\"perm_name\":\"active\",\"parent\":\"owner\",\"required_auth\":{\"threshold\":1,\"keys\":[{\"key\":\"EOS6gqJ7sdPgjHLFLtks9cRPs5qYHa9U3CwK4P2JasTLWKQ9kXZK1\",\"weight\":1}],\"accounts\":[],\"waits\":[]},\"linked_actions\":[]},{\"perm_name\":\"claim\",\"parent\":\"active\",\"required_auth\":{\"threshold\":1,\"keys\":[{\"key\":\"EOS6DLD9HxMcwn73U41jjdGsNe9vDFRKB26um6qTAqrtYcJFtED4C\",\"weight\":1}],\"accounts\":[],\"waits\":[]},\"linked_actions\":[{\"account\":\"eosio\",\"action\":\"claimrewards\"}]},{\"perm_name\":\"decentium\",\"parent\":\"active\",\"required_auth\":{\"threshold\":1,\"keys\":[{\"key\":\"EOS7knG7M5TUEdRv1bkVjTPddVoDQnwS7oEZXAgFk3A4hhocA3eJf\",\"weight\":1}],\"accounts\":[],\"waits\":[]},\"linked_actions\":[{\"account\":\"decentiumorg\"}]},{\"perm_name\":\"killswitch\",\"parent\":\"active\",\"required_auth\":{\"threshold\":1,\"keys\":[{\"key\":\"EOS7CjC7GL71msPzAuAzd2WwiBEAzTcPL47ACrjSuiNmnnGGufYSn\",\"weight\":1}],\"accounts\":[],\"waits\":[]},\"linked_actions\":[{\"account\":\"eosio\",\"action\":\"unregprod\"}]},{\"perm_name\":\"oracle\",\"parent\":\"active\",\"required_auth\":{\"threshold\":1,\"keys\":[{\"key\":\"EOS88VqmDmJJ9S23eNqdeWYf2zySxv3ckQrWBKy7EvVRCUuhSU4f3\",\"weight\":1}],\"accounts\":[],\"waits\":[]},\"linked_actions\":[{\"account\":\"delphioracle\",\"action\":\"write\"}]},{\"perm_name\":\"owner\",\"parent\":\"\",\"required_auth\":{\"threshold\":1,\"keys\":[{\"key\":\"EOS8QzGtCea2thiqcTVeXGdyRZpdKYptQznbcWSMj73FD5RgwKN82\",\"weight\":1}],\"accounts\":[],\"waits\":[]},\"linked_actions\":[]},{\"perm_name\":\"producerjson\",\"parent\":\"active\",\"required_auth\":{\"threshold\":1,\"keys\":[{\"key\":\"EOS5JCEciUdfXnQmTyj85T98bXTAZZ1g7Nmajseu7ZWB8DrDa6Etp\",\"weight\":1}],\"accounts\":[],\"waits\":[]},\"linked_actions\":[{\"account\":\"producerjson\",\"action\":\"set\"}]},{\"perm_name\":\"transfer\",\"parent\":\"active\",\"required_auth\":{\"threshold\":1,\"keys\":[{\"key\":\"EOS7qZ8nnmn6KBnjQL4oukyZFWCj8DmC9nJE2nkAYAZbwgKhMu8cW\",\"weight\":1}],\"accounts\":[],\"waits\":[]},\"linked_actions\":[{\"account\":\"eosio.token\",\"action\":\"transfer\"}]},{\"perm_name\":\"vote\",\"parent\":\"active\",\"required_auth\":{\"threshold\":1,\"keys\":[{\"key\":\"EOS65NrHPVXaV4voxepQREmYCmnMJm4tAWdxPaK46CbUN1rrVmRzg\",\"weight\":1}],\"accounts\":[],\"waits\":[]},\"linked_actions\":[{\"account\":\"eosio\",\"action\":\"voteproducer\"}]},{\"perm_name\":\"voting\",\"parent\":\"active\",\"required_auth\":{\"threshold\":1,\"keys\":[{\"key\":\"EOS7pn6P5FftyNAKRfx9VcUzBFMvC4UitNbnoKbfxNe8SShELo2it\",\"weight\":1}],\"accounts\":[],\"waits\":[]},\"linked_actions\":[{\"account\":\"eosio.forum\",\"action\":\"vote\"},{\"account\":\"eosio.forum\",\"action\":\"unvote\"}]}],\"total_resources\":{\"owner\":\"teamgreymass\",\"net_weight\":\"449.6541 EOS\",\"cpu_weight\":\"1348314.6062 EOS\",\"ram_bytes\":66588},\"self_delegated_bandwidth\":null,\"refund_request\":null,\"voter_info\":{\"owner\":\"teamgreymass\",\"proxy\":\"greymassvote\",\"producers\":[],\"staked\":100202,\"last_vote_weight\":\"863265464502.93908691406250000\",\"proxied_vote_weight\":\"0.00000000000000000\",\"is_proxy\":0,\"flags1\":0,\"reserved2\":0,\"reserved3\":\"0.0000 EOS\"},\"rex_info\":null,\"subjective_cpu_bill_limit\":{\"used\":0,\"available\":0,\"max\":0,\"last_usage_update_time\":\"2000-01-01T00:00:00.000\",\"current_used\":0},\"eosio_any_linked_actions\":[]}"
+}

--- a/test/data/8982bb3c2b325ba2365896eb649c1614f30ae941.json
+++ b/test/data/8982bb3c2b325ba2365896eb649c1614f30ae941.json
@@ -1,0 +1,161 @@
+{
+    "request": {
+        "path": "https://telos.greymass.com/v1/chain/get_account",
+        "params": {
+            "method": "POST",
+            "body": "{\"account_name\":\"teamgreymass\"}"
+        }
+    },
+    "status": 200,
+    "json": {
+        "account_name": "teamgreymass",
+        "head_block_num": 296749908,
+        "head_block_time": "2023-08-29T18:14:04.500",
+        "privileged": false,
+        "last_code_update": "1970-01-01T00:00:00.000",
+        "created": "2018-12-12T17:46:49.000",
+        "core_liquid_balance": "175444.8919 TLOS",
+        "ram_quota": 16716,
+        "net_weight": 10000,
+        "cpu_weight": 1000000,
+        "net_limit": {
+            "used": 630,
+            "available": 43014828,
+            "max": 43015458,
+            "last_usage_update_time": "2023-08-29T14:24:02.500",
+            "current_used": 529
+        },
+        "cpu_limit": {
+            "used": 1474,
+            "available": 680677851,
+            "max": 680679325,
+            "last_usage_update_time": "2023-08-29T14:24:02.500",
+            "current_used": 1239
+        },
+        "ram_usage": 7328,
+        "permissions": [
+            {
+                "perm_name": "active",
+                "parent": "owner",
+                "required_auth": {
+                    "threshold": 1,
+                    "keys": [
+                        {
+                            "key": "EOS6gqJ7sdPgjHLFLtks9cRPs5qYHa9U3CwK4P2JasTLWKQ9kXZK1",
+                            "weight": 1
+                        }
+                    ],
+                    "accounts": [],
+                    "waits": []
+                },
+                "linked_actions": []
+            },
+            {
+                "perm_name": "claim",
+                "parent": "active",
+                "required_auth": {
+                    "threshold": 1,
+                    "keys": [
+                        {
+                            "key": "EOS6DLD9HxMcwn73U41jjdGsNe9vDFRKB26um6qTAqrtYcJFtED4C",
+                            "weight": 1
+                        }
+                    ],
+                    "accounts": [],
+                    "waits": []
+                },
+                "linked_actions": [
+                    {
+                        "account": "eosio",
+                        "action": "claimrewards"
+                    }
+                ]
+            },
+            {
+                "perm_name": "owner",
+                "parent": "",
+                "required_auth": {
+                    "threshold": 1,
+                    "keys": [
+                        {
+                            "key": "EOS8QzGtCea2thiqcTVeXGdyRZpdKYptQznbcWSMj73FD5RgwKN82",
+                            "weight": 1
+                        }
+                    ],
+                    "accounts": [],
+                    "waits": []
+                },
+                "linked_actions": []
+            },
+            {
+                "perm_name": "producerjson",
+                "parent": "active",
+                "required_auth": {
+                    "threshold": 1,
+                    "keys": [
+                        {
+                            "key": "EOS5JCEciUdfXnQmTyj85T98bXTAZZ1g7Nmajseu7ZWB8DrDa6Etp",
+                            "weight": 1
+                        }
+                    ],
+                    "accounts": [],
+                    "waits": []
+                },
+                "linked_actions": [
+                    {
+                        "account": "producerjson",
+                        "action": "set"
+                    }
+                ]
+            }
+        ],
+        "total_resources": {
+            "owner": "teamgreymass",
+            "net_weight": "1.0000 TLOS",
+            "cpu_weight": "100.0000 TLOS",
+            "ram_bytes": 15316
+        },
+        "self_delegated_bandwidth": {
+            "from": "teamgreymass",
+            "to": "teamgreymass",
+            "net_weight": "1.0000 TLOS",
+            "cpu_weight": "100.0000 TLOS"
+        },
+        "refund_request": null,
+        "voter_info": {
+            "owner": "teamgreymass",
+            "proxy": "",
+            "producers": [],
+            "staked": "6682315286",
+            "last_stake": 0,
+            "last_vote_weight": "0.00000000000000000",
+            "proxied_vote_weight": "0.00000000000000000",
+            "is_proxy": 0,
+            "flags1": 0,
+            "reserved2": 0,
+            "reserved3": "0 "
+        },
+        "rex_info": {
+            "version": 0,
+            "owner": "teamgreymass",
+            "vote_stake": "568130.5286 TLOS",
+            "rex_balance": "3326896774.2846 REX",
+            "matured_rex": "28424569078808",
+            "rex_maturities": [
+                {
+                    "first": "2023-02-22T00:00:00",
+                    "second": "4844398664038"
+                }
+            ]
+        },
+        "subjective_cpu_bill_limit": {
+            "used": 0,
+            "available": 0,
+            "max": 0,
+            "last_usage_update_time": "2000-01-01T00:00:00.000",
+            "current_used": 0
+        },
+        "eosio_any_linked_actions": []
+    },
+    "text": "{\"account_name\":\"teamgreymass\",\"head_block_num\":296749908,\"head_block_time\":\"2023-08-29T18:14:04.500\",\"privileged\":false,\"last_code_update\":\"1970-01-01T00:00:00.000\",\"created\":\"2018-12-12T17:46:49.000\",\"core_liquid_balance\":\"175444.8919 TLOS\",\"ram_quota\":16716,\"net_weight\":10000,\"cpu_weight\":1000000,\"net_limit\":{\"used\":630,\"available\":43014828,\"max\":43015458,\"last_usage_update_time\":\"2023-08-29T14:24:02.500\",\"current_used\":529},\"cpu_limit\":{\"used\":1474,\"available\":680677851,\"max\":680679325,\"last_usage_update_time\":\"2023-08-29T14:24:02.500\",\"current_used\":1239},\"ram_usage\":7328,\"permissions\":[{\"perm_name\":\"active\",\"parent\":\"owner\",\"required_auth\":{\"threshold\":1,\"keys\":[{\"key\":\"EOS6gqJ7sdPgjHLFLtks9cRPs5qYHa9U3CwK4P2JasTLWKQ9kXZK1\",\"weight\":1}],\"accounts\":[],\"waits\":[]},\"linked_actions\":[]},{\"perm_name\":\"claim\",\"parent\":\"active\",\"required_auth\":{\"threshold\":1,\"keys\":[{\"key\":\"EOS6DLD9HxMcwn73U41jjdGsNe9vDFRKB26um6qTAqrtYcJFtED4C\",\"weight\":1}],\"accounts\":[],\"waits\":[]},\"linked_actions\":[{\"account\":\"eosio\",\"action\":\"claimrewards\"}]},{\"perm_name\":\"owner\",\"parent\":\"\",\"required_auth\":{\"threshold\":1,\"keys\":[{\"key\":\"EOS8QzGtCea2thiqcTVeXGdyRZpdKYptQznbcWSMj73FD5RgwKN82\",\"weight\":1}],\"accounts\":[],\"waits\":[]},\"linked_actions\":[]},{\"perm_name\":\"producerjson\",\"parent\":\"active\",\"required_auth\":{\"threshold\":1,\"keys\":[{\"key\":\"EOS5JCEciUdfXnQmTyj85T98bXTAZZ1g7Nmajseu7ZWB8DrDa6Etp\",\"weight\":1}],\"accounts\":[],\"waits\":[]},\"linked_actions\":[{\"account\":\"producerjson\",\"action\":\"set\"}]}],\"total_resources\":{\"owner\":\"teamgreymass\",\"net_weight\":\"1.0000 TLOS\",\"cpu_weight\":\"100.0000 TLOS\",\"ram_bytes\":15316},\"self_delegated_bandwidth\":{\"from\":\"teamgreymass\",\"to\":\"teamgreymass\",\"net_weight\":\"1.0000 TLOS\",\"cpu_weight\":\"100.0000 TLOS\"},\"refund_request\":null,\"voter_info\":{\"owner\":\"teamgreymass\",\"proxy\":\"\",\"producers\":[],\"staked\":\"6682315286\",\"last_stake\":0,\"last_vote_weight\":\"0.00000000000000000\",\"proxied_vote_weight\":\"0.00000000000000000\",\"is_proxy\":0,\"flags1\":0,\"reserved2\":0,\"reserved3\":\"0 \"},\"rex_info\":{\"version\":0,\"owner\":\"teamgreymass\",\"vote_stake\":\"568130.5286 TLOS\",\"rex_balance\":\"3326896774.2846 REX\",\"matured_rex\":\"28424569078808\",\"rex_maturities\":[{\"first\":\"2023-02-22T00:00:00\",\"second\":\"4844398664038\"}]},\"subjective_cpu_bill_limit\":{\"used\":0,\"available\":0,\"max\":0,\"last_usage_update_time\":\"2000-01-01T00:00:00.000\",\"current_used\":0},\"eosio_any_linked_actions\":[]}"
+}

--- a/test/data/ef20dbcccffc6200cd24d5706914d7f0202a9a56.json
+++ b/test/data/ef20dbcccffc6200cd24d5706914d7f0202a9a56.json
@@ -1,0 +1,283 @@
+{
+    "request": {
+        "path": "https://wax.greymass.com/v1/chain/get_account",
+        "params": {
+            "method": "POST",
+            "body": "{\"account_name\":\"teamgreymass\"}"
+        }
+    },
+    "status": 200,
+    "json": {
+        "account_name": "teamgreymass",
+        "head_block_num": 263563615,
+        "head_block_time": "2023-08-28T20:01:17.500",
+        "privileged": false,
+        "last_code_update": "1970-01-01T00:00:00.000",
+        "created": "2019-07-12T05:18:07.000",
+        "core_liquid_balance": "2274987.96962515 WAX",
+        "ram_quota": 20957,
+        "net_weight": "455096542392",
+        "cpu_weight": "555196542594",
+        "net_limit": {
+            "used": 194185,
+            "available": 541775903,
+            "max": 541970088,
+            "last_usage_update_time": "2023-08-28T20:00:20.000",
+            "current_used": 194055
+        },
+        "cpu_limit": {
+            "used": 461994,
+            "available": 500254732,
+            "max": 500716726,
+            "last_usage_update_time": "2023-08-28T20:00:20.000",
+            "current_used": 461687
+        },
+        "ram_usage": 12523,
+        "permissions": [
+            {
+                "perm_name": "active",
+                "parent": "owner",
+                "required_auth": {
+                    "threshold": 1,
+                    "keys": [
+                        {
+                            "key": "EOS8KmhygTrrvtW7zJd6HXWrNqA5WX9NzScZ37JyXRiwpiJN2g2rR",
+                            "weight": 1
+                        }
+                    ],
+                    "accounts": [],
+                    "waits": []
+                },
+                "linked_actions": []
+            },
+            {
+                "perm_name": "claim",
+                "parent": "active",
+                "required_auth": {
+                    "threshold": 1,
+                    "keys": [
+                        {
+                            "key": "EOS6DLD9HxMcwn73U41jjdGsNe9vDFRKB26um6qTAqrtYcJFtED4C",
+                            "weight": 1
+                        }
+                    ],
+                    "accounts": [],
+                    "waits": []
+                },
+                "linked_actions": [
+                    {
+                        "account": "eosio",
+                        "action": "claimrewards"
+                    },
+                    {
+                        "account": "eosio",
+                        "action": "claimgenesis"
+                    },
+                    {
+                        "account": "eosio",
+                        "action": "claimgbmvote"
+                    },
+                    {
+                        "account": "eosio",
+                        "action": "claimgbmprod"
+                    }
+                ]
+            },
+            {
+                "perm_name": "failover",
+                "parent": "active",
+                "required_auth": {
+                    "threshold": 1,
+                    "keys": [
+                        {
+                            "key": "EOS8NKyWVSfbfmyU98y6AfvJ8QfwbtNKAgfnZ9BbWd3UvQzMHhJY6",
+                            "weight": 1
+                        }
+                    ],
+                    "accounts": [],
+                    "waits": []
+                },
+                "linked_actions": [
+                    {
+                        "account": "eosio",
+                        "action": "regproducer"
+                    }
+                ]
+            },
+            {
+                "perm_name": "killswitch",
+                "parent": "active",
+                "required_auth": {
+                    "threshold": 1,
+                    "keys": [
+                        {
+                            "key": "EOS7CjC7GL71msPzAuAzd2WwiBEAzTcPL47ACrjSuiNmnnGGufYSn",
+                            "weight": 1
+                        }
+                    ],
+                    "accounts": [],
+                    "waits": []
+                },
+                "linked_actions": [
+                    {
+                        "account": "eosio",
+                        "action": "unregprod"
+                    }
+                ]
+            },
+            {
+                "perm_name": "oracle",
+                "parent": "active",
+                "required_auth": {
+                    "threshold": 1,
+                    "keys": [
+                        {
+                            "key": "EOS88VqmDmJJ9S23eNqdeWYf2zySxv3ckQrWBKy7EvVRCUuhSU4f3",
+                            "weight": 1
+                        }
+                    ],
+                    "accounts": [],
+                    "waits": []
+                },
+                "linked_actions": [
+                    {
+                        "account": "delphioracle",
+                        "action": "write"
+                    }
+                ]
+            },
+            {
+                "perm_name": "owner",
+                "parent": "",
+                "required_auth": {
+                    "threshold": 1,
+                    "keys": [
+                        {
+                            "key": "EOS76TP8M48sRBGdPmsKyy3qAMCYgBNswjaWaXGR4jkS5Hro16khr",
+                            "weight": 1
+                        }
+                    ],
+                    "accounts": [],
+                    "waits": []
+                },
+                "linked_actions": []
+            },
+            {
+                "perm_name": "producerjson",
+                "parent": "active",
+                "required_auth": {
+                    "threshold": 1,
+                    "keys": [
+                        {
+                            "key": "EOS5JCEciUdfXnQmTyj85T98bXTAZZ1g7Nmajseu7ZWB8DrDa6Etp",
+                            "weight": 1
+                        }
+                    ],
+                    "accounts": [],
+                    "waits": []
+                },
+                "linked_actions": [
+                    {
+                        "account": "producerjson",
+                        "action": "set"
+                    }
+                ]
+            },
+            {
+                "perm_name": "transfer",
+                "parent": "active",
+                "required_auth": {
+                    "threshold": 1,
+                    "keys": [
+                        {
+                            "key": "EOS6AkZZ5YZ6G5eCQGJBAPbkmouEaiSKFkdM289wEMKcf2rnx7mrb",
+                            "weight": 1
+                        },
+                        {
+                            "key": "EOS6RWZ1CmDL4B6LdixuertnzxcRuUDac3NQspJEvMnebGcUwhvfX",
+                            "weight": 1
+                        }
+                    ],
+                    "accounts": [],
+                    "waits": []
+                },
+                "linked_actions": [
+                    {
+                        "account": "eosio.token",
+                        "action": "transfer"
+                    }
+                ]
+            }
+        ],
+        "total_resources": {
+            "owner": "teamgreymass",
+            "net_weight": "4550.96542392 WAX",
+            "cpu_weight": "5551.96542594 WAX",
+            "ram_bytes": 19557
+        },
+        "self_delegated_bandwidth": {
+            "from": "teamgreymass",
+            "to": "teamgreymass",
+            "net_weight": "4550.96542392 WAX",
+            "cpu_weight": "5551.96542594 WAX"
+        },
+        "refund_request": null,
+        "voter_info": {
+            "owner": "teamgreymass",
+            "proxy": "",
+            "producers": [
+                "3dkrenderwax",
+                "alohaeosprod",
+                "amsterdamwax",
+                "blacklusionx",
+                "blokcrafters",
+                "bountyblokbp",
+                "bp.box",
+                "bp.wecan",
+                "cryptolions1",
+                "dapplica",
+                "eosauthority",
+                "eosdacserver",
+                "eosdublinwow",
+                "eosiodetroit",
+                "eosphereiobp",
+                "eosriobrazil",
+                "greeneosiobp",
+                "guild.nefty",
+                "hkeosguildhk",
+                "ivote4waxusa",
+                "ledgerwiseio",
+                "liquidstudio",
+                "nation.wax",
+                "pink.gg",
+                "sentnlagents",
+                "teamgreymass",
+                "tokengamerio",
+                "wax.eastern",
+                "waxhiveguild",
+                "waxswedenorg"
+            ],
+            "staked": "9039133084986",
+            "unpaid_voteshare": "0.00000000000000000",
+            "unpaid_voteshare_last_updated": "2023-08-28T17:28:26.500",
+            "unpaid_voteshare_change_rate": "84871176772458765566336581970335981633536.00000000000000000",
+            "last_claim_time": "2023-08-28T17:28:26.500",
+            "last_vote_weight": "84871176772458765566336581970335981633536.00000000000000000",
+            "proxied_vote_weight": "0.00000000000000000",
+            "is_proxy": 0,
+            "flags1": 0,
+            "reserved2": 0,
+            "reserved3": "0 "
+        },
+        "rex_info": null,
+        "subjective_cpu_bill_limit": {
+            "used": 0,
+            "available": 0,
+            "max": 0,
+            "last_usage_update_time": "2000-01-01T00:00:00.000",
+            "current_used": 0
+        },
+        "eosio_any_linked_actions": []
+    },
+    "text": "{\"account_name\":\"teamgreymass\",\"head_block_num\":263563615,\"head_block_time\":\"2023-08-28T20:01:17.500\",\"privileged\":false,\"last_code_update\":\"1970-01-01T00:00:00.000\",\"created\":\"2019-07-12T05:18:07.000\",\"core_liquid_balance\":\"2274987.96962515 WAX\",\"ram_quota\":20957,\"net_weight\":\"455096542392\",\"cpu_weight\":\"555196542594\",\"net_limit\":{\"used\":194185,\"available\":541775903,\"max\":541970088,\"last_usage_update_time\":\"2023-08-28T20:00:20.000\",\"current_used\":194055},\"cpu_limit\":{\"used\":461994,\"available\":500254732,\"max\":500716726,\"last_usage_update_time\":\"2023-08-28T20:00:20.000\",\"current_used\":461687},\"ram_usage\":12523,\"permissions\":[{\"perm_name\":\"active\",\"parent\":\"owner\",\"required_auth\":{\"threshold\":1,\"keys\":[{\"key\":\"EOS8KmhygTrrvtW7zJd6HXWrNqA5WX9NzScZ37JyXRiwpiJN2g2rR\",\"weight\":1}],\"accounts\":[],\"waits\":[]},\"linked_actions\":[]},{\"perm_name\":\"claim\",\"parent\":\"active\",\"required_auth\":{\"threshold\":1,\"keys\":[{\"key\":\"EOS6DLD9HxMcwn73U41jjdGsNe9vDFRKB26um6qTAqrtYcJFtED4C\",\"weight\":1}],\"accounts\":[],\"waits\":[]},\"linked_actions\":[{\"account\":\"eosio\",\"action\":\"claimrewards\"},{\"account\":\"eosio\",\"action\":\"claimgenesis\"},{\"account\":\"eosio\",\"action\":\"claimgbmvote\"},{\"account\":\"eosio\",\"action\":\"claimgbmprod\"}]},{\"perm_name\":\"failover\",\"parent\":\"active\",\"required_auth\":{\"threshold\":1,\"keys\":[{\"key\":\"EOS8NKyWVSfbfmyU98y6AfvJ8QfwbtNKAgfnZ9BbWd3UvQzMHhJY6\",\"weight\":1}],\"accounts\":[],\"waits\":[]},\"linked_actions\":[{\"account\":\"eosio\",\"action\":\"regproducer\"}]},{\"perm_name\":\"killswitch\",\"parent\":\"active\",\"required_auth\":{\"threshold\":1,\"keys\":[{\"key\":\"EOS7CjC7GL71msPzAuAzd2WwiBEAzTcPL47ACrjSuiNmnnGGufYSn\",\"weight\":1}],\"accounts\":[],\"waits\":[]},\"linked_actions\":[{\"account\":\"eosio\",\"action\":\"unregprod\"}]},{\"perm_name\":\"oracle\",\"parent\":\"active\",\"required_auth\":{\"threshold\":1,\"keys\":[{\"key\":\"EOS88VqmDmJJ9S23eNqdeWYf2zySxv3ckQrWBKy7EvVRCUuhSU4f3\",\"weight\":1}],\"accounts\":[],\"waits\":[]},\"linked_actions\":[{\"account\":\"delphioracle\",\"action\":\"write\"}]},{\"perm_name\":\"owner\",\"parent\":\"\",\"required_auth\":{\"threshold\":1,\"keys\":[{\"key\":\"EOS76TP8M48sRBGdPmsKyy3qAMCYgBNswjaWaXGR4jkS5Hro16khr\",\"weight\":1}],\"accounts\":[],\"waits\":[]},\"linked_actions\":[]},{\"perm_name\":\"producerjson\",\"parent\":\"active\",\"required_auth\":{\"threshold\":1,\"keys\":[{\"key\":\"EOS5JCEciUdfXnQmTyj85T98bXTAZZ1g7Nmajseu7ZWB8DrDa6Etp\",\"weight\":1}],\"accounts\":[],\"waits\":[]},\"linked_actions\":[{\"account\":\"producerjson\",\"action\":\"set\"}]},{\"perm_name\":\"transfer\",\"parent\":\"active\",\"required_auth\":{\"threshold\":1,\"keys\":[{\"key\":\"EOS6AkZZ5YZ6G5eCQGJBAPbkmouEaiSKFkdM289wEMKcf2rnx7mrb\",\"weight\":1},{\"key\":\"EOS6RWZ1CmDL4B6LdixuertnzxcRuUDac3NQspJEvMnebGcUwhvfX\",\"weight\":1}],\"accounts\":[],\"waits\":[]},\"linked_actions\":[{\"account\":\"eosio.token\",\"action\":\"transfer\"}]}],\"total_resources\":{\"owner\":\"teamgreymass\",\"net_weight\":\"4550.96542392 WAX\",\"cpu_weight\":\"5551.96542594 WAX\",\"ram_bytes\":19557},\"self_delegated_bandwidth\":{\"from\":\"teamgreymass\",\"to\":\"teamgreymass\",\"net_weight\":\"4550.96542392 WAX\",\"cpu_weight\":\"5551.96542594 WAX\"},\"refund_request\":null,\"voter_info\":{\"owner\":\"teamgreymass\",\"proxy\":\"\",\"producers\":[\"3dkrenderwax\",\"alohaeosprod\",\"amsterdamwax\",\"blacklusionx\",\"blokcrafters\",\"bountyblokbp\",\"bp.box\",\"bp.wecan\",\"cryptolions1\",\"dapplica\",\"eosauthority\",\"eosdacserver\",\"eosdublinwow\",\"eosiodetroit\",\"eosphereiobp\",\"eosriobrazil\",\"greeneosiobp\",\"guild.nefty\",\"hkeosguildhk\",\"ivote4waxusa\",\"ledgerwiseio\",\"liquidstudio\",\"nation.wax\",\"pink.gg\",\"sentnlagents\",\"teamgreymass\",\"tokengamerio\",\"wax.eastern\",\"waxhiveguild\",\"waxswedenorg\"],\"staked\":\"9039133084986\",\"unpaid_voteshare\":\"0.00000000000000000\",\"unpaid_voteshare_last_updated\":\"2023-08-28T17:28:26.500\",\"unpaid_voteshare_change_rate\":\"84871176772458765566336581970335981633536.00000000000000000\",\"last_claim_time\":\"2023-08-28T17:28:26.500\",\"last_vote_weight\":\"84871176772458765566336581970335981633536.00000000000000000\",\"proxied_vote_weight\":\"0.00000000000000000\",\"is_proxy\":0,\"flags1\":0,\"reserved2\":0,\"reserved3\":\"0 \"},\"rex_info\":null,\"subjective_cpu_bill_limit\":{\"used\":0,\"available\":0,\"max\":0,\"last_usage_update_time\":\"2000-01-01T00:00:00.000\",\"current_used\":0},\"eosio_any_linked_actions\":[]}"
+}

--- a/test/tests/chains.ts
+++ b/test/tests/chains.ts
@@ -1,11 +1,18 @@
 import {assert} from 'chai'
-import {mockFetch} from '@wharfkit/mock-data'
+import {
+    mockFetch,
+    mockSessionKitArgs,
+    mockSessionKitOptions,
+    MockUserInterface,
+} from '@wharfkit/mock-data'
 
-import {ChainDefinition, chainIdsToIndices, ChainNames, Chains} from '$lib'
+import {ChainDefinition, ChainDefinitionType, chainIdsToIndices, Chains, getChainClient} from '$lib'
 import {BaseAPIClient} from '@wharfkit/antelope'
 
 import {APIClient as LeapAPIClient} from '@wharfkit/apiclient-leap'
+import {APIClient as TelosAPIClient} from '@wharfkit/apiclient-telos'
 import {APIClient as WAXAPIClient} from '@wharfkit/apiclient-wax'
+import {SessionKit} from '@wharfkit/session'
 
 suite('chains', function () {
     suite('chainIdsToIndices', function () {
@@ -15,44 +22,187 @@ suite('chains', function () {
                 assert.isTrue(def.id.equals(chainId), `${indice}: ${def.id} !== ${chainId}`)
             }
         })
-        test('chainIdToIndices -> ChainNames', function () {
-            for (const [, indice] of chainIdsToIndices) {
-                const name = ChainNames[indice]
-                assert.isDefined(name, `Not defined - ${indice}: ${name}`)
-            }
-        })
     })
     suite('Chains', function () {
         test('valid data', function () {
             for (const [, indice] of chainIdsToIndices) {
                 const def = Chains[indice]
                 assert.instanceOf(def, ChainDefinition)
-                assert.equal(def.name, ChainNames[indice])
             }
         })
     })
-    suite('APIClient', function () {
-        test('returns instance of base client', function () {
-            const client = Chains.EOS.getClient({fetch: mockFetch})
+    suite('getChainClient', function () {
+        test('returns instance of leap client', async function () {
+            const client = getChainClient(Chains.EOS.id, {
+                url: 'https://eos.greymass.com',
+                fetch: mockFetch,
+            })
             assert.instanceOf(client, BaseAPIClient)
-        })
-        test('returns default APIClient', async function () {
-            const client = Chains.EOS.getClient({fetch: mockFetch})
             assert.instanceOf(client, LeapAPIClient)
+            assert.notInstanceOf(client, TelosAPIClient)
+            assert.notInstanceOf(client, WAXAPIClient)
             const account = await client.v1.chain.get_account('teamgreymass')
             if (account.voter_info) {
                 // Ensure this field doesn't exist on the results (since its WAX specific)
                 assert.isUndefined(account.voter_info['unpaid_voteshare'])
+                // Ensure this field doesn't exist on the results (since its Telos specific)
+                assert.isUndefined(account.voter_info['last_stake'])
             }
         })
-        test('WAX returns custom APIClient', async function () {
-            const client = Chains.WAX.getClient({fetch: mockFetch})
+        test('returns instance of leap client using generics', async function () {
+            const client = getChainClient<'EOS'>(Chains.EOS.id, {
+                url: 'https://eos.greymass.com',
+                fetch: mockFetch,
+            })
+            assert.instanceOf(client, BaseAPIClient)
+            assert.instanceOf(client, LeapAPIClient)
+            assert.notInstanceOf(client, TelosAPIClient)
+            assert.notInstanceOf(client, WAXAPIClient)
+            const account = await client.v1.chain.get_account('teamgreymass')
+            if (account.voter_info) {
+                // Ensure this field doesn't exist on the results (since its WAX specific)
+                assert.isUndefined(account.voter_info['unpaid_voteshare'])
+                // Ensure this field doesn't exist on the results (since its Telos specific)
+                assert.isUndefined(account.voter_info['last_stake'])
+            }
+        })
+        test('returns instance of wax client', async function () {
+            const client = getChainClient(Chains.WAX.id, {
+                url: 'https://wax.greymass.com',
+                fetch: mockFetch,
+            })
+            assert.instanceOf(client, BaseAPIClient)
+            assert.instanceOf(client, LeapAPIClient)
+            assert.notInstanceOf(client, TelosAPIClient)
+            assert.instanceOf(client, WAXAPIClient)
+            const account = await client.v1.chain.get_account('teamgreymass')
+            if (account.voter_info) {
+                // Ensure this field does exist on the results (since this is WAX)
+                assert.isDefined(account.voter_info['unpaid_voteshare'])
+                // Ensure this field doesn't exist on the results (since its Telos specific)
+                assert.isUndefined(account.voter_info['last_stake'])
+            }
+        })
+        test('returns instance of wax client using generics', async function () {
+            const client = getChainClient<'WAX'>(Chains.WAX.id, {
+                url: 'https://wax.greymass.com',
+                fetch: mockFetch,
+            })
+            assert.instanceOf(client, BaseAPIClient)
+            assert.instanceOf(client, LeapAPIClient)
+            assert.notInstanceOf(client, TelosAPIClient)
             assert.instanceOf(client, WAXAPIClient)
             const account = await client.v1.chain.get_account('teamgreymass')
             if (account.voter_info) {
                 // Ensure this field does exist on the results (since this is WAX)
                 assert.isDefined(account.voter_info.unpaid_voteshare)
+                // Ensure this field doesn't exist on the results (since its Telos specific)
+                assert.isUndefined(account.voter_info['last_stake'])
             }
+        })
+        test('returns instance of telos client', async function () {
+            const client = getChainClient(Chains.Telos.id, {
+                url: 'https://telos.greymass.com',
+                fetch: mockFetch,
+            })
+            assert.instanceOf(client, BaseAPIClient)
+            assert.instanceOf(client, LeapAPIClient)
+            assert.instanceOf(client, TelosAPIClient)
+            assert.notInstanceOf(client, WAXAPIClient)
+            const account = await client.v1.chain.get_account('teamgreymass')
+            if (account.voter_info) {
+                // Ensure this field does exist on the results (since this is Telos)
+                assert.isDefined(account.voter_info['last_stake'])
+                // Ensure this field doesn't exist on the results (since its WAX specific)
+                assert.isUndefined(account.voter_info['unpaid_voteshare'])
+            }
+        })
+        test('returns instance of telos client using generics', async function () {
+            const client = getChainClient<'Telos'>(Chains.Telos.id, {
+                url: 'https://telos.greymass.com',
+                fetch: mockFetch,
+            })
+            assert.instanceOf(client, BaseAPIClient)
+            assert.instanceOf(client, LeapAPIClient)
+            assert.instanceOf(client, TelosAPIClient)
+            assert.notInstanceOf(client, WAXAPIClient)
+            const account = await client.v1.chain.get_account('teamgreymass')
+            if (account.voter_info) {
+                // Ensure this field does exist on the results (since this is Telos)
+                assert.isDefined(account.voter_info.last_stake)
+                // Ensure this field doesn't exist on the results (since its WAX specific)
+                assert.isUndefined(account.voter_info['unpaid_voteshare'])
+            }
+        })
+    })
+    suite('chains constant w/ built-in generics', function () {
+        test('returns default instance of leap client', async function () {
+            // Using the `Chains` constant, the generics are predefined so the developer doesn't need to define them
+            const client = Chains.EOS.getClient({fetch: mockFetch})
+            const account = await client.v1.chain.get_account('teamgreymass')
+            if (account.voter_info) {
+                // Ensure neither of these fields exist since they are not part of the Leap implementation
+                assert.isUndefined(account.voter_info['unpaid_voteshare'])
+                assert.isUndefined(account.voter_info['last_stake'])
+            }
+        })
+        test('returns instance of wax client', async function () {
+            // Using the `Chains` constant, the generics are predefined so the developer doesn't need to define them
+            const client = Chains.WAX.getClient({fetch: mockFetch})
+            const account = await client.v1.chain.get_account('teamgreymass')
+            if (account.voter_info) {
+                // The `voter_info` contains `unpaid_voteshare` for WAX and Typescript won't error
+                assert.isDefined(account.voter_info.unpaid_voteshare)
+            }
+        })
+        test('returns instance of telos client', async function () {
+            // Using the `Chains` constant, the generics are predefined so the developer doesn't need to define them
+            const client = Chains.Telos.getClient({fetch: mockFetch})
+            const account = await client.v1.chain.get_account('teamgreymass')
+            if (account.voter_info) {
+                // The `voter_info` contains `last_stake` for Telos and Typescript won't error
+                assert.isDefined(account.voter_info.last_stake)
+            }
+        })
+    })
+    suite('api types from session kit', function () {
+        test('can handle `Chains` definitions', async function () {
+            // The `Chains` const has WAX defined as a `ChainDefinition<'WAX'>` instance
+            const def1 = Chains.WAX
+            const client1 = def1.getClient({fetch: mockFetch})
+            // Should be WAXAPIClient instance
+            const result1 = await client1.v1.chain.get_account('teamgreymass')
+            // Result will be WAXAccountObject from the WAXAPIClient
+
+            console.log(result1)
+
+            // Setup a SessionKit and pass in the generic `ChainDefintion<'WAX'>`
+            const kit = new SessionKit(
+                {
+                    ...mockSessionKitArgs,
+                    chains: [Chains.WAX],
+                },
+                mockSessionKitOptions
+            )
+
+            // Get it back from the Kit
+            const defInKit = kit.chains[0]
+            // Result should be a `ChainDefinition<'WAX'>` instance, but is a `ChainDefinition` instance
+            // Without using generics on the `SessionKit` itself, I don't think we can return a generically typed `ChainDefinition`
+            // ????
+
+            console.log(defInKit)
+
+            // The kit.getChainDefinition() returns whatever was passed above
+            const def2 = kit.getChainDefinition(Chains.WAX.id)
+            const client2 = def2.getClient({fetch: mockFetch})
+            // Should be WAXAPIClient instance
+            const result2 = await client2.v1.chain.get_account('teamgreymass')
+            // Should be WAXAccountObject from the WAXAPIClient
+            console.log(result2)
+
+            // const test2 = def.getClient({fetch: mockFetch})
+            // console.log(test2)
         })
     })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1344,7 +1344,7 @@
     hash.js "^1.0.0"
     tslib "^2.0.3"
 
-"@wharfkit/antelope@^0.9.0-rc1", "@wharfkit/antelope@^0.9.0-rc2":
+"@wharfkit/antelope@^0.9.0-rc2":
   version "0.9.0-rc2"
   resolved "https://registry.yarnpkg.com/@wharfkit/antelope/-/antelope-0.9.0-rc2.tgz#a8fe53fb7874e4af2b5bd9982c43bbe117f57037"
   integrity sha512-9uvPHv4TZIKdtrnI1ECfER0k/+cgHfLzOoho3psGbxxbbvoUPhyRyFBY2uFWEYlLp230X5H9PMpoUKc4cidoGA==
@@ -1356,21 +1356,29 @@
     pako "^2.1.0"
     tslib "^2.0.3"
 
-"@wharfkit/apiclient-leap@^4.0.3":
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/@wharfkit/apiclient-leap/-/apiclient-leap-4.0.3.tgz#067eb38753bb022906205974062f10d1d476b1a2"
-  integrity sha512-H4kMdG628uzUN2ZmN+umIMSGA2DR8Hc5Kg0SwVolYIQlmkPLYd9CGLrRsMDqhLVeE+nGLm/w7an3nvNndLQb3g==
+"@wharfkit/apiclient-leap@^4.0.5":
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/@wharfkit/apiclient-leap/-/apiclient-leap-4.0.5.tgz#fcfee265f098dd165d68c1116077f0e651349cb2"
+  integrity sha512-7dR5tL5MRL/P9dreLF7a4qXdhVHkWdGUapdVaKu04dzMnTO8BfVvwnIP6N2oxnBdzVdLjnAClPK9+ye7KI58GA==
   dependencies:
-    "@wharfkit/antelope" "^0.9.0-rc1"
+    "@wharfkit/antelope" "^0.9.0-rc2"
     pako "^2.1.0"
     tslib "^2.0.3"
 
-"@wharfkit/apiclient-wax@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@wharfkit/apiclient-wax/-/apiclient-wax-4.0.2.tgz#e54699df745218142f4f0cfae8d5d72ecfded9dd"
-  integrity sha512-U92Qmnjsb/q50GlFYBkQ/XsRBTFszGoQUwyNS3X/Hs4CygIp4g4QM5DnvZeOoHMImDZAlcpnpymbZHS3uxUzVw==
+"@wharfkit/apiclient-telos@^4.0.5":
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/@wharfkit/apiclient-telos/-/apiclient-telos-4.0.5.tgz#a3414c0a6055ae8356c8f5568360e6b7105262bb"
+  integrity sha512-pz71RwCLyITJUOE5dBumGWgq3aS9RWp2e20R7LZyUuy+oxPrBJrfpIQWuoq5V5FRZkYJ2a1j89CLB1aNIWcF/A==
   dependencies:
-    "@wharfkit/apiclient-leap" "^4.0.3"
+    "@wharfkit/apiclient-leap" "^4.0.5"
+    tslib "^2.0.3"
+
+"@wharfkit/apiclient-wax@^4.0.5":
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/@wharfkit/apiclient-wax/-/apiclient-wax-4.0.5.tgz#5612df17944df308fbf48983af2963b2c85c288a"
+  integrity sha512-ZAPO09/Xeqe9eZ6iLOhemmcbcMDgqP8SHPEUjGjCLut21Q9L1YtSS3aBE2UtBZgFUJoDBTAKV5Fks+AkCbWP8Q==
+  dependencies:
+    "@wharfkit/apiclient-leap" "^4.0.5"
     tslib "^2.0.3"
 
 "@wharfkit/common@^1.1.0":

--- a/yarn.lock
+++ b/yarn.lock
@@ -1031,15 +1031,10 @@
     "@jridgewell/sourcemap-codec" "^1.4.10"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@jridgewell/resolve-uri@3.1.0":
+"@jridgewell/resolve-uri@3.1.0", "@jridgewell/resolve-uri@^3.0.3":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz#2203b118c157721addfe69d47b70465463066d78"
   integrity sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==
-
-"@jridgewell/resolve-uri@^3.0.3":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz#c08679063f279615a3326583ba3a90d1d82cc721"
-  integrity sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==
 
 "@jridgewell/set-array@^1.0.1":
   version "1.1.2"
@@ -1054,15 +1049,10 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@jridgewell/sourcemap-codec@1.4.14":
+"@jridgewell/sourcemap-codec@1.4.14", "@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.13":
   version "1.4.14"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
   integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
-
-"@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.13":
-  version "1.4.15"
-  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
-  integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
 
 "@jridgewell/trace-mapping@0.3.9":
   version "0.3.9"
@@ -1232,12 +1222,7 @@
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-9.1.1.tgz#e7c4f1001eefa4b8afbd1eee27a237fee3bf29c4"
   integrity sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==
 
-"@types/node@*":
-  version "20.4.5"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.4.5.tgz#9dc0a5cb1ccce4f7a731660935ab70b9c00a5d69"
-  integrity sha512-rt40Nk13II9JwQBdeYqmbn2Q6IVTA5uPhvSO+JVqdXw/6/4glI6oR9ezty/A9Hg5u7JH4OmYmuQ+XvjKm0Datg==
-
-"@types/node@^18.7.18":
+"@types/node@*", "@types/node@^18.7.18":
   version "18.17.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.17.1.tgz#84c32903bf3a09f7878c391d31ff08f6fe7d8335"
   integrity sha512-xlR1jahfizdplZYRU59JlUx9uzF1ARa8jbhM11ccpCJya8kvos5jwdm2ZAgxSCwOl0fq21svP18EVwPBXMQudw==
@@ -1338,6 +1323,16 @@
     "@typescript-eslint/types" "5.62.0"
     eslint-visitor-keys "^3.3.0"
 
+"@wharfkit/abicache@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@wharfkit/abicache/-/abicache-1.1.1.tgz#03624d03d9466e7def278786aaf074d274fc5650"
+  integrity sha512-CfpHzCLxFATcfReqdJDUxEDSHIeBF3jFx0cP8RcTDyhC2jX4cd+Q/wqjw/kCni3xrBM7cIGUp9c9NZdvdTK9Cg==
+  dependencies:
+    "@wharfkit/antelope" "^0.7.3"
+    "@wharfkit/signing-request" "^3.0.0"
+    pako "^2.0.4"
+    tslib "^2.1.0"
+
 "@wharfkit/antelope@^0.7.3":
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/@wharfkit/antelope/-/antelope-0.7.3.tgz#408f6c587f4f5990d4b55596c10be2e976798641"
@@ -1348,6 +1343,80 @@
     elliptic "^6.5.4"
     hash.js "^1.0.0"
     tslib "^2.0.3"
+
+"@wharfkit/antelope@^0.9.0-rc1", "@wharfkit/antelope@^0.9.0-rc2":
+  version "0.9.0-rc2"
+  resolved "https://registry.yarnpkg.com/@wharfkit/antelope/-/antelope-0.9.0-rc2.tgz#a8fe53fb7874e4af2b5bd9982c43bbe117f57037"
+  integrity sha512-9uvPHv4TZIKdtrnI1ECfER0k/+cgHfLzOoho3psGbxxbbvoUPhyRyFBY2uFWEYlLp230X5H9PMpoUKc4cidoGA==
+  dependencies:
+    bn.js "^4.11.9"
+    brorand "^1.1.0"
+    elliptic "^6.5.4"
+    hash.js "^1.0.0"
+    pako "^2.1.0"
+    tslib "^2.0.3"
+
+"@wharfkit/apiclient-leap@^4.0.3":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@wharfkit/apiclient-leap/-/apiclient-leap-4.0.3.tgz#067eb38753bb022906205974062f10d1d476b1a2"
+  integrity sha512-H4kMdG628uzUN2ZmN+umIMSGA2DR8Hc5Kg0SwVolYIQlmkPLYd9CGLrRsMDqhLVeE+nGLm/w7an3nvNndLQb3g==
+  dependencies:
+    "@wharfkit/antelope" "^0.9.0-rc1"
+    pako "^2.1.0"
+    tslib "^2.0.3"
+
+"@wharfkit/apiclient-wax@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@wharfkit/apiclient-wax/-/apiclient-wax-4.0.2.tgz#e54699df745218142f4f0cfae8d5d72ecfded9dd"
+  integrity sha512-U92Qmnjsb/q50GlFYBkQ/XsRBTFszGoQUwyNS3X/Hs4CygIp4g4QM5DnvZeOoHMImDZAlcpnpymbZHS3uxUzVw==
+  dependencies:
+    "@wharfkit/apiclient-leap" "^4.0.3"
+    tslib "^2.0.3"
+
+"@wharfkit/common@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@wharfkit/common/-/common-1.1.0.tgz#1ee9dd1ba9e202002fadd20593f5f42a3e67c827"
+  integrity sha512-A1Ta8zrEXkuEQcEiEexG0BVrYOxqm75qbLYU9tGNhyw4z/vQiF6rzmCOqhmWGg6nE2J2GYPvrPZPZzDmRGtG+w==
+  dependencies:
+    tslib "^2.1.0"
+
+"@wharfkit/mock-data@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@wharfkit/mock-data/-/mock-data-1.0.2.tgz#81d6327c76032b40e5acf209d507cf6ca2a3ae9f"
+  integrity sha512-Mbf/rZX2dqj5r+h+6NcRsDfRdHZ5OWEk0oIZ6iarXEBV65jmODoLdZlS906m9ndC1bi1ewCm/276JDimIqtLkQ==
+  dependencies:
+    "@wharfkit/antelope" "^0.7.3"
+    "@wharfkit/session" "^1.0.0"
+    "@wharfkit/wallet-plugin-privatekey" "^1.0.0"
+    node-fetch "^2.6.1"
+    tslib "^2.1.0"
+
+"@wharfkit/session@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@wharfkit/session/-/session-1.0.0.tgz#09c60d01a6185ab2e451d34462d84de2d7013220"
+  integrity sha512-wXmvOVBZ1Rp/9HPUzGPaD/vpGXv2FCNgl8JRLopKgKPHkkEX/u4untshHR8AwSc0ZitjOlv6ubR2h9/UW8h6ug==
+  dependencies:
+    "@wharfkit/abicache" "^1.1.1"
+    "@wharfkit/antelope" "^0.7.3"
+    "@wharfkit/common" "^1.1.0"
+    "@wharfkit/signing-request" "^3.0.0"
+    pako "^2.0.4"
+    tslib "^2.1.0"
+
+"@wharfkit/signing-request@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@wharfkit/signing-request/-/signing-request-3.0.0.tgz#3464cdc76c0690ab241d805116101e3ed63ba846"
+  integrity sha512-+9UaznhYlZSgdZGG/LF5GkH7P9dCVh+b32cR1PYHKG6KuOsPlLqfv1DuWkqsxQyi3kGT1fXG1i8sl39ItgwLzg==
+  dependencies:
+    "@wharfkit/antelope" "^0.7.3"
+    tslib "^2.0.3"
+
+"@wharfkit/wallet-plugin-privatekey@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@wharfkit/wallet-plugin-privatekey/-/wallet-plugin-privatekey-1.0.0.tgz#2600cce1117ce9391c8078649e05ceaf93780f1d"
+  integrity sha512-V+/7T/cwoHM8fDaM3MZ1DFKrX2+NddBkkWJ8BIFfmEZnGR1W8Qr77t+piOP0/6UM2etmuZh98XLwZS33vORQ0A==
+  dependencies:
+    tslib "^2.1.0"
 
 "@yarnpkg/lockfile@^1.1.0":
   version "1.1.0"
@@ -2186,7 +2255,7 @@ glob-parent@^6.0.2:
   dependencies:
     is-glob "^4.0.3"
 
-glob@7.2.0:
+glob@7.2.0, glob@^7.0.3, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
   integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
@@ -2195,18 +2264,6 @@ glob@7.2.0:
     inflight "^1.0.4"
     inherits "2"
     minimatch "^3.0.4"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-glob@^7.0.3, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
-  version "7.2.3"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
-  integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.1.1"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
@@ -2729,7 +2786,7 @@ minimatch@5.0.1:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
+minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
@@ -2799,6 +2856,13 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
+
+node-fetch@^2.6.1:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
+  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
+  dependencies:
+    whatwg-url "^5.0.0"
 
 node-preload@^0.2.1:
   version "0.2.1"
@@ -2923,6 +2987,11 @@ package-hash@^4.0.0:
     hasha "^5.0.0"
     lodash.flattendeep "^4.4.0"
     release-zalgo "^1.0.0"
+
+pako@^2.0.4, pako@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-2.1.0.tgz#266cc37f98c7d883545d11335c00fbd4062c9a86"
+  integrity sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==
 
 parent-module@^1.0.0:
   version "1.0.1"
@@ -3395,6 +3464,11 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
+
 trim-repeated@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/trim-repeated/-/trim-repeated-1.0.0.tgz#e3646a2ea4e891312bf7eace6cfb05380bc01c21"
@@ -3561,6 +3635,19 @@ vscode-textmate@^8.0.0:
   resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-8.0.0.tgz#2c7a3b1163ef0441097e0b5d6389cd5504b59e5d"
   integrity sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==
 
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
+
 which-module@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.1.tgz#776b1fe35d90aebe99e8ac15eb24093389a4a409"
@@ -3631,7 +3718,7 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yargs-parser@20.2.4:
+yargs-parser@20.2.4, yargs-parser@^20.2.2:
   version "20.2.4"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.4.tgz#b42890f14566796f85ae8e3a25290d205f154a54"
   integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
@@ -3643,11 +3730,6 @@ yargs-parser@^18.1.2:
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
-
-yargs-parser@^20.2.2:
-  version "20.2.9"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
-  integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
 
 yargs-unparser@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Each ChainDefinition can now return an appropriately typed APIClient based on which blockchain it is.

The typescript generics here are messy (I think?) but they work.